### PR TITLE
Add Google Search Console verification and submit sitemaps

### DIFF
--- a/app.py
+++ b/app.py
@@ -489,7 +489,16 @@ def terms():
 
 # ── SEO routes ─────────────────────────────────────────────────────────────────
 
-BASE_URL = "https://ibrary-safety-checker-production.up.railway.app"
+BASE_URL = "https://ibrary-safety-checker-production-1526.up.railway.app"
+
+@app.route("/googleef147e2249f09263.html")
+def google_verification():
+    """Serve Google Search Console HTML verification file."""
+    content = "google-site-verification: googleef147e2249f09263.html"
+    response = make_response(content)
+    response.headers["Content-Type"] = "text/html; charset=utf-8"
+    return response
+
 
 @app.route("/robots.txt")
 def robots_txt():

--- a/templates/base.html
+++ b/templates/base.html
@@ -14,6 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <meta name="keywords" content="{% block meta_keywords %}library safety checker, package security, vulnerability scanner, OSV database, PyPI security, open source vulnerabilities, dependency analysis, CVE checker, npm security, python package safety{% endblock %}">
   <meta name="author" content="Library Safety Checker">
   <meta name="robots" content="{% block meta_robots %}index, follow{% endblock %}">
+  <meta name="google-site-verification" content="ef147e2249f09263">
   <meta name="theme-color" content="#0f172a">
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-capable" content="yes">
@@ -21,14 +22,14 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <meta name="apple-mobile-web-app-title" content="Library Safety Checker">
 
   <!-- Canonical URL -->
-  <link rel="canonical" href="{% block canonical_url %}https://ibrary-safety-checker-production.up.railway.app{{ request.path }}{% endblock %}">
+  <link rel="canonical" href="{% block canonical_url %}https://ibrary-safety-checker-production-1526.up.railway.app{{ request.path }}{% endblock %}">
 
   <!-- Open Graph -->
   <meta property="og:type"        content="{% block og_type %}website{% endblock %}">
   <meta property="og:site_name"   content="Library Safety Checker">
   <meta property="og:title"       content="{% block og_title %}Library Safety Checker – Free Package Vulnerability Scanner{% endblock %}">
   <meta property="og:description" content="{% block og_description %}Instantly scan open-source packages for vulnerabilities, check licenses, and analyze dependencies. Powered by OSV, PyPI, and GitHub data.{% endblock %}">
-  <meta property="og:url"         content="https://ibrary-safety-checker-production.up.railway.app{{ request.path }}">
+  <meta property="og:url"         content="https://ibrary-safety-checker-production-1526.up.railway.app{{ request.path }}">
   <meta property="og:locale"      content="en_US">
 
   <!-- Twitter Card -->
@@ -53,17 +54,17 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     "@graph": [
       {
         "@type": "Organization",
-        "@id": "https://ibrary-safety-checker-production.up.railway.app/#organization",
+        "@id": "https://ibrary-safety-checker-production-1526.up.railway.app/#organization",
         "name": "Library Safety Checker",
-        "url": "https://ibrary-safety-checker-production.up.railway.app",
+        "url": "https://ibrary-safety-checker-production-1526.up.railway.app",
         "description": "Free open-source package vulnerability scanner powered by OSV, PyPI, and GitHub data.",
         "sameAs": ["https://github.com/Arv1121/ibrary-safety-checker"]
       },
       {
         "@type": "WebApplication",
-        "@id": "https://ibrary-safety-checker-production.up.railway.app/#webapp",
+        "@id": "https://ibrary-safety-checker-production-1526.up.railway.app/#webapp",
         "name": "Library Safety Checker",
-        "url": "https://ibrary-safety-checker-production.up.railway.app",
+        "url": "https://ibrary-safety-checker-production-1526.up.railway.app",
         "applicationCategory": "SecurityApplication",
         "operatingSystem": "Any",
         "browserRequirements": "Requires JavaScript",
@@ -74,7 +75,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           "priceCurrency": "USD"
         },
         "publisher": {
-          "@id": "https://ibrary-safety-checker-production.up.railway.app/#organization"
+          "@id": "https://ibrary-safety-checker-production-1526.up.railway.app/#organization"
         },
         "featureList": [
           "CVE vulnerability scanning via OSV database",
@@ -87,17 +88,17 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       },
       {
         "@type": "WebSite",
-        "@id": "https://ibrary-safety-checker-production.up.railway.app/#website",
-        "url": "https://ibrary-safety-checker-production.up.railway.app",
+        "@id": "https://ibrary-safety-checker-production-1526.up.railway.app/#website",
+        "url": "https://ibrary-safety-checker-production-1526.up.railway.app",
         "name": "Library Safety Checker",
         "publisher": {
-          "@id": "https://ibrary-safety-checker-production.up.railway.app/#organization"
+          "@id": "https://ibrary-safety-checker-production-1526.up.railway.app/#organization"
         },
         "potentialAction": {
           "@type": "SearchAction",
           "target": {
             "@type": "EntryPoint",
-            "urlTemplate": "https://ibrary-safety-checker-production.up.railway.app/search?package={search_term_string}&ecosystem=PyPI"
+            "urlTemplate": "https://ibrary-safety-checker-production-1526.up.railway.app/search?package={search_term_string}&ecosystem=PyPI"
           },
           "query-input": "required name=search_term_string"
         }


### PR DESCRIPTION
## Summary

Adds the Google Search Console verification meta tag (`ef147e2249f09263`, sourced from the existing `googleef147e2249f09263.html` file in the repo) to `base.html` so Google can verify site ownership. Also adds a Flask route in `app.py` to serve the HTML verification file at `/googleef147e2249f09263.html`. Updates `BASE_URL` in `app.py` and all canonical/OG/JSON-LD URLs in `base.html` from the old `ibrary-safety-checker-production.up.railway.app` domain to the Search Console-registered domain `ibrary-safety-checker-production-1526.up.railway.app`, ensuring sitemaps and structured data point to the correct verified property.

### Changes
- **Modified** `templates/base.html`
- **Modified** `app.py`

---
*Generated by [Railway](https://railway.com)*