### PR TITLE
Rebrand website to OSS Security Hub

### DIFF
--- a/app.py
+++ b/app.py
@@ -529,7 +529,7 @@ def fetch_cargo_meta(package):
     """Fetch package metadata from crates.io."""
     try:
         r = requests.get(CARGO_API.format(package=package), timeout=10,
-                         headers={"User-Agent": "library-safety-checker/1.0"})
+                         headers={"User-Agent": "oss-security-hub/1.0"})
         if r.status_code != 200:
             return None
         data = r.json()

--- a/templates/base.html
+++ b/templates/base.html
@@ -10,35 +10,35 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <!-- End Google Tag Manager -->
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
-  <meta name="description" content="{% block meta_description %}Library Safety Checker – real-time vulnerability scanning, dependency analysis, and security scoring for open-source packages. Check PyPI, npm, and Maven packages instantly.{% endblock %}">
+  <meta name="description" content="{% block meta_description %}OSS Security Hub – real-time vulnerability scanning, dependency analysis, and security scoring for open-source packages. Check PyPI, npm, and Maven packages instantly.{% endblock %}">
   <meta name="keywords" content="{% block meta_keywords %}library safety checker, package security, vulnerability scanner, OSV database, PyPI security, open source vulnerabilities, dependency analysis, CVE checker, npm security, python package safety{% endblock %}">
-  <meta name="author" content="Library Safety Checker">
+  <meta name="author" content="OSS Security Hub">
   <meta name="robots" content="{% block meta_robots %}index, follow{% endblock %}">
   <meta name="google-site-verification" content="ef147e2249f09263">
   <meta name="theme-color" content="#0f172a">
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-  <meta name="apple-mobile-web-app-title" content="Library Safety Checker">
+  <meta name="apple-mobile-web-app-title" content="OSS Security Hub">
 
   <!-- Canonical URL -->
   <link rel="canonical" href="{% block canonical_url %}https://ibrary-safety-checker-production-1526.up.railway.app{{ request.path }}{% endblock %}">
 
   <!-- Open Graph -->
   <meta property="og:type"        content="{% block og_type %}website{% endblock %}">
-  <meta property="og:site_name"   content="Library Safety Checker">
-  <meta property="og:title"       content="{% block og_title %}Library Safety Checker – Free Package Vulnerability Scanner{% endblock %}">
+  <meta property="og:site_name"   content="OSS Security Hub">
+  <meta property="og:title"       content="{% block og_title %}OSS Security Hub – Free Package Vulnerability Scanner{% endblock %}">
   <meta property="og:description" content="{% block og_description %}Instantly scan open-source packages for vulnerabilities, check licenses, and analyze dependencies. Powered by OSV, PyPI, and GitHub data.{% endblock %}">
   <meta property="og:url"         content="https://ibrary-safety-checker-production-1526.up.railway.app{{ request.path }}">
   <meta property="og:locale"      content="en_US">
 
   <!-- Twitter Card -->
   <meta name="twitter:card"        content="summary_large_image">
-  <meta name="twitter:site"        content="@LibrarySafety">
-  <meta name="twitter:title"       content="{% block tw_title %}Library Safety Checker – Free Package Vulnerability Scanner{% endblock %}">
+  <meta name="twitter:site"        content="@OSSSecurityHub">
+  <meta name="twitter:title"       content="{% block tw_title %}OSS Security Hub – Free Package Vulnerability Scanner{% endblock %}">
   <meta name="twitter:description" content="{% block tw_description %}Instantly scan open-source packages for known vulnerabilities, license issues, and maintenance status. Free, real-time, powered by OSV.{% endblock %}">
 
-  <title>{% block title %}Library Safety Checker – Free Package Vulnerability Scanner{% endblock %}</title>
+  <title>{% block title %}OSS Security Hub – Free Package Vulnerability Scanner{% endblock %}</title>
 
   <!-- Tailwind CSS -->
   <script src="https://cdn.tailwindcss.com"></script>
@@ -55,7 +55,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       {
         "@type": "Organization",
         "@id": "https://ibrary-safety-checker-production-1526.up.railway.app/#organization",
-        "name": "Library Safety Checker",
+        "name": "OSS Security Hub",
         "url": "https://ibrary-safety-checker-production-1526.up.railway.app",
         "description": "Free open-source package vulnerability scanner powered by OSV, PyPI, and GitHub data.",
         "sameAs": ["https://github.com/Arv1121/ibrary-safety-checker"]
@@ -63,7 +63,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       {
         "@type": "WebApplication",
         "@id": "https://ibrary-safety-checker-production-1526.up.railway.app/#webapp",
-        "name": "Library Safety Checker",
+        "name": "OSS Security Hub",
         "url": "https://ibrary-safety-checker-production-1526.up.railway.app",
         "applicationCategory": "SecurityApplication",
         "operatingSystem": "Any",
@@ -90,7 +90,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         "@type": "WebSite",
         "@id": "https://ibrary-safety-checker-production-1526.up.railway.app/#website",
         "url": "https://ibrary-safety-checker-production-1526.up.railway.app",
-        "name": "Library Safety Checker",
+        "name": "OSS Security Hub",
         "publisher": {
           "@id": "https://ibrary-safety-checker-production-1526.up.railway.app/#organization"
         },
@@ -125,8 +125,8 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <!-- Brand -->
       <a href="/" class="flex items-center gap-2 shrink-0">
         <span class="text-2xl">📦</span>
-        <span class="font-bold text-lg gradient-text hidden sm:inline">Library Safety Checker</span>
-        <span class="font-bold text-lg gradient-text sm:hidden">LSC</span>
+        <span class="font-bold text-lg gradient-text hidden sm:inline">OSS Security Hub</span>
+        <span class="font-bold text-lg gradient-text sm:hidden">OSH</span>
       </a>
 
       <!-- Nav links -->
@@ -184,7 +184,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       </div>
 
       <div class="border-t border-white/10 pt-6 flex flex-col sm:flex-row justify-between items-center gap-3 text-sm text-slate-500">
-        <p>© 2026 Library Safety Checker. All rights reserved.</p>
+        <p>© 2026 OSS Security Hub. All rights reserved.</p>
         <div class="flex gap-4">
           <a href="/terms" class="hover:text-white transition">Terms</a>
           <a href="https://github.com/Arv1121/ibrary-safety-checker" target="_blank" rel="noopener" class="hover:text-white transition">GitHub ↗</a>

--- a/templates/comparison.html
+++ b/templates/comparison.html
@@ -1,12 +1,12 @@
 {% extends "base.html" %}
 
-{% block title %}{% if pkgs %}Compare {{ pkgs | join(' vs ') }} – Security Analysis{% else %}Compare Python Packages – Library Safety Checker{% endif %}{% endblock %}
+{% block title %}{% if pkgs %}Compare {{ pkgs | join(' vs ') }} – Security Analysis{% else %}Compare Python Packages – OSS Security Hub{% endif %}{% endblock %}
 {% block meta_description %}{% if pkgs %}Side-by-side security comparison of {{ pkgs | join(', ') }}: vulnerabilities, licenses, GitHub stats, and safety verdicts.{% else %}Compare up to 3 open-source packages side by side. Analyze vulnerabilities, licenses, GitHub metrics, and safety verdicts.{% endif %}{% endblock %}
 {% block meta_keywords %}compare python packages, package security comparison, vulnerability comparison, open source package analysis, PyPI package comparison{% endblock %}
 {% block meta_robots %}{% if pkgs %}index, follow{% else %}noindex, follow{% endif %}{% endblock %}
-{% block og_title %}{% if pkgs %}{{ pkgs | join(' vs ') }} – Security Comparison{% else %}Package Comparison – Library Safety Checker{% endif %}{% endblock %}
-{% block og_description %}{% if pkgs %}Compare security profiles of {{ pkgs | join(', ') }}: vulnerability counts, license compliance, and GitHub health metrics.{% else %}Compare up to 3 open-source packages side by side on Library Safety Checker.{% endif %}{% endblock %}
-{% block tw_title %}{% if pkgs %}{{ pkgs | join(' vs ') }} Security Comparison{% else %}Compare Python Packages – Library Safety Checker{% endif %}{% endblock %}
+{% block og_title %}{% if pkgs %}{{ pkgs | join(' vs ') }} – Security Comparison{% else %}Package Comparison – OSS Security Hub{% endif %}{% endblock %}
+{% block og_description %}{% if pkgs %}Compare security profiles of {{ pkgs | join(', ') }}: vulnerability counts, license compliance, and GitHub health metrics.{% else %}Compare up to 3 open-source packages side by side on OSS Security Hub.{% endif %}{% endblock %}
+{% block tw_title %}{% if pkgs %}{{ pkgs | join(' vs ') }} Security Comparison{% else %}Compare Python Packages – OSS Security Hub{% endif %}{% endblock %}
 {% block canonical_url %}https://ibrary-safety-checker-production.up.railway.app/compare{% if pkgs %}?{% for p in pkgs %}pkg={{ p }}{% if not loop.last %}&{% endif %}{% endfor %}{% endif %}{% endblock %}
 
 {% block content %}

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,11 +1,11 @@
 {% extends "base.html" %}
 
-{% block title %}OSS Security Dashboard – Library Safety Checker{% endblock %}
+{% block title %}OSS Security Dashboard – OSS Security Hub{% endblock %}
 {% block meta_description %}Real-time security dashboard for popular packages across all ecosystems. View vulnerability counts, license status, and safety verdicts for PyPI, npm, Maven, Go, Rust, NuGet, RubyGems, Composer, and AI/ML packages.{% endblock %}
 {% block meta_keywords %}package security dashboard, OSS vulnerability dashboard, multi-ecosystem security, PyPI npm Maven Go Rust NuGet security, AI ML package safety, tensorflow pytorch security, open source security monitoring{% endblock %}
-{% block og_title %}OSS Security Dashboard – Multi-Ecosystem Package Safety{% endblock %}
+{% block og_title %}OSS Security Dashboard – OSS Security Hub{% endblock %}
 {% block og_description %}Real-time security status for popular packages across PyPI, npm, Maven, Go, Rust, NuGet, RubyGems, Composer, and AI/ML ecosystems. Filter by verdict, sort by vulnerabilities.{% endblock %}
-{% block tw_title %}OSS Security Dashboard – Multi-Ecosystem Package Safety{% endblock %}
+{% block tw_title %}OSS Security Dashboard – OSS Security Hub{% endblock %}
 {% block tw_description %}Monitor security status of packages across 8 ecosystems in real time. Full AI/ML coverage: TensorFlow, PyTorch, scikit-learn, Hugging Face, and more.{% endblock %}
 {% block canonical_url %}https://ibrary-safety-checker-production.up.railway.app/dashboard{% endblock %}
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,11 +1,11 @@
 {% extends "base.html" %}
 
-{% block title %}Library Safety Checker – Free Package Vulnerability Scanner{% endblock %}
+{% block title %}OSS Security Hub – Free Package Vulnerability Scanner{% endblock %}
 {% block meta_description %}Free multi-ecosystem package vulnerability scanner. Instantly check PyPI, npm, Maven, Go, Rust, NuGet, RubyGems, and Composer packages for CVEs, license issues, and maintenance status using the OSV database. Full AI/ML package coverage including TensorFlow, PyTorch, and Hugging Face.{% endblock %}
-{% block meta_keywords %}library safety checker, package vulnerability scanner, PyPI security check, npm vulnerability scan, open source CVE checker, OSV database, python package security, dependency vulnerability analysis, tensorflow security, pytorch vulnerability, AI ML package safety, rust cargo security, nuget vulnerability, rubygems security{% endblock %}
-{% block og_title %}Library Safety Checker – Free Multi-Ecosystem Package Vulnerability Scanner{% endblock %}
+{% block meta_keywords %}OSS security hub, package vulnerability scanner, PyPI security check, npm vulnerability scan, open source CVE checker, OSV database, python package security, dependency vulnerability analysis, tensorflow security, pytorch vulnerability, AI ML package safety, rust cargo security, nuget vulnerability, rubygems security{% endblock %}
+{% block og_title %}OSS Security Hub – Free Multi-Ecosystem Package Vulnerability Scanner{% endblock %}
 {% block og_description %}Instantly scan any open-source package for known CVEs, license compliance issues, and maintenance health. Supports PyPI, npm, Maven, Go, Rust, NuGet, RubyGems, Composer, and all major AI/ML packages. Free, real-time results powered by OSV.{% endblock %}
-{% block tw_title %}Library Safety Checker – Free Multi-Ecosystem Package Vulnerability Scanner{% endblock %}
+{% block tw_title %}OSS Security Hub – Free Multi-Ecosystem Package Vulnerability Scanner{% endblock %}
 {% block tw_description %}Scan PyPI, npm, Maven, Go, Rust, NuGet, and more for CVEs in seconds. Full AI/ML coverage: TensorFlow, PyTorch, scikit-learn, Hugging Face. Powered by OSV.{% endblock %}
 {% block canonical_url %}https://ibrary-safety-checker-production.up.railway.app/{% endblock %}
 
@@ -18,10 +18,10 @@
     "mainEntity": [
       {
         "@type": "Question",
-        "name": "What is Library Safety Checker?",
+        "name": "What is OSS Security Hub?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Library Safety Checker is a free tool that scans open-source packages for known vulnerabilities (CVEs), license compliance issues, and maintenance health using the OSV database, PyPI, and GitHub data."
+          "text": "OSS Security Hub is a free tool that scans open-source packages for known vulnerabilities (CVEs), license compliance issues, and maintenance health using the OSV database, PyPI, and GitHub data."
         }
       },
       {
@@ -29,7 +29,7 @@
         "name": "Which package ecosystems are supported?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Library Safety Checker supports PyPI (Python), npm (JavaScript), Maven (Java), Go, Cargo/crates.io (Rust), NuGet (.NET/C#), RubyGems (Ruby), and Composer/Packagist (PHP). It also provides comprehensive coverage of AI/ML packages including TensorFlow, PyTorch, JAX, scikit-learn, Hugging Face Transformers, LangChain, and 100+ more."
+          "text": "OSS Security Hub supports PyPI (Python), npm (JavaScript), Maven (Java), Go, Cargo/crates.io (Rust), NuGet (.NET/C#), RubyGems (Ruby), and Composer/Packagist (PHP). It also provides comprehensive coverage of AI/ML packages including TensorFlow, PyTorch, JAX, scikit-learn, Hugging Face Transformers, LangChain, and 100+ more."
         }
       },
       {

--- a/templates/results.html
+++ b/templates/results.html
@@ -5,10 +5,10 @@
 {% block meta_keywords %}{{ package }} vulnerability, {{ package }} security, {{ package }} CVE, {{ ecosystem }} package safety, {{ package }} license, open source security{% endblock %}
 {% block meta_robots %}{% if verdict == 'Error' %}noindex, follow{% else %}index, follow{% endif %}{% endblock %}
 {% block og_type %}article{% endblock %}
-{% block og_title %}{{ package }} – Security Report | Library Safety Checker{% endblock %}
+{% block og_title %}{{ package }} – Security Report | OSS Security Hub{% endblock %}
 {% block og_description %}{{ verdict }} verdict for {{ package }} v{{ meta.version if meta else 'unknown' }}. {{ vulns|length }} vulnerabilities found. License: {{ meta.license if meta else 'unknown' }}. Powered by OSV, PyPI, and GitHub data.{% endblock %}
 {% block tw_title %}{{ package }} Security Report – {{ verdict }}{% endblock %}
-{% block tw_description %}{{ vulns|length }} vulnerabilities found in {{ package }}. Verdict: {{ verdict }}. Check license compliance and dependency health on Library Safety Checker.{% endblock %}
+{% block tw_description %}{{ vulns|length }} vulnerabilities found in {{ package }}. Verdict: {{ verdict }}. Check license compliance and dependency health on OSS Security Hub.{% endblock %}
 {% block canonical_url %}https://ibrary-safety-checker-production.up.railway.app/search?package={{ package }}&ecosystem={{ ecosystem }}{% endblock %}
 
 {% block extra_head %}

--- a/templates/terms.html
+++ b/templates/terms.html
@@ -1,11 +1,11 @@
 {% extends "base.html" %}
 
-{% block title %}Terms & Conditions – Library Safety Checker{% endblock %}
-{% block meta_description %}Terms and conditions for using the Library Safety Checker service, including data privacy, third-party APIs, and limitations of liability.{% endblock %}
-{% block meta_keywords %}library safety checker terms, terms of service, privacy policy, data usage{% endblock %}
+{% block title %}Terms & Conditions – OSS Security Hub{% endblock %}
+{% block meta_description %}Terms and conditions for using the OSS Security Hub service, including data privacy, third-party APIs, and limitations of liability.{% endblock %}
+{% block meta_keywords %}OSS security hub terms, terms of service, privacy policy, data usage{% endblock %}
 {% block meta_robots %}index, follow{% endblock %}
-{% block og_title %}Terms & Conditions – Library Safety Checker{% endblock %}
-{% block og_description %}Read the terms and conditions for using Library Safety Checker, including data privacy practices and third-party API usage.{% endblock %}
+{% block og_title %}Terms & Conditions – OSS Security Hub{% endblock %}
+{% block og_description %}Read the terms and conditions for using OSS Security Hub, including data privacy practices and third-party API usage.{% endblock %}
 {% block canonical_url %}https://ibrary-safety-checker-production.up.railway.app/terms{% endblock %}
 
 {% block content %}
@@ -17,14 +17,14 @@
     <section>
       <h2 class="text-2xl font-bold mb-3">1. Acceptance of Terms</h2>
       <p class="text-slate-300 leading-relaxed">
-        By accessing and using the Library Safety Checker website and services, you accept and agree to be bound by the terms and provisions of this agreement. If you do not agree to abide by the above, please do not use this service.
+        By accessing and using the OSS Security Hub website and services, you accept and agree to be bound by the terms and provisions of this agreement. If you do not agree to abide by the above, please do not use this service.
       </p>
     </section>
 
     <section>
       <h2 class="text-2xl font-bold mb-3">2. Use License</h2>
       <p class="text-slate-300 leading-relaxed mb-4">
-        Permission is granted to temporarily access the materials on Library Safety Checker for personal, non-commercial transitory viewing only. Under this license you may not:
+        Permission is granted to temporarily access the materials on OSS Security Hub for personal, non-commercial transitory viewing only. Under this license you may not:
       </p>
       <ul class="list-disc list-inside text-slate-300 space-y-2 ml-4">
         <li>Modify or copy the materials</li>
@@ -39,38 +39,38 @@
     <section>
       <h2 class="text-2xl font-bold mb-3">3. Disclaimer</h2>
       <p class="text-slate-300 leading-relaxed">
-        The materials on Library Safety Checker are provided on an 'as is' basis. Library Safety Checker makes no warranties, expressed or implied, and hereby disclaims all other warranties including, without limitation, implied warranties of merchantability, fitness for a particular purpose, or non-infringement of intellectual property.
+        The materials on OSS Security Hub are provided on an 'as is' basis. OSS Security Hub makes no warranties, expressed or implied, and hereby disclaims all other warranties including, without limitation, implied warranties of merchantability, fitness for a particular purpose, or non-infringement of intellectual property.
       </p>
       <p class="text-slate-300 leading-relaxed mt-4">
-        Library Safety Checker does not warrant or make any representations concerning the accuracy, likely results, or reliability of the use of the materials on its website.
+        OSS Security Hub does not warrant or make any representations concerning the accuracy, likely results, or reliability of the use of the materials on its website.
       </p>
     </section>
 
     <section>
       <h2 class="text-2xl font-bold mb-3">4. Limitations</h2>
       <p class="text-slate-300 leading-relaxed">
-        In no event shall Library Safety Checker or its suppliers be liable for any damages (including, without limitation, damages for loss of data or profit, or due to business interruption) arising out of the use or inability to use the materials on Library Safety Checker.
+        In no event shall OSS Security Hub or its suppliers be liable for any damages (including, without limitation, damages for loss of data or profit, or due to business interruption) arising out of the use or inability to use the materials on OSS Security Hub.
       </p>
     </section>
 
     <section>
       <h2 class="text-2xl font-bold mb-3">5. Accuracy of Materials</h2>
       <p class="text-slate-300 leading-relaxed">
-        The materials appearing on Library Safety Checker could include technical, typographical, or photographic errors. Library Safety Checker does not warrant that any of the materials on its website are accurate, complete, or current. Library Safety Checker may make changes to the materials at any time without notice.
+        The materials appearing on OSS Security Hub could include technical, typographical, or photographic errors. OSS Security Hub does not warrant that any of the materials on its website are accurate, complete, or current. OSS Security Hub may make changes to the materials at any time without notice.
       </p>
     </section>
 
     <section>
       <h2 class="text-2xl font-bold mb-3">6. Links</h2>
       <p class="text-slate-300 leading-relaxed">
-        Library Safety Checker has not reviewed all of the sites linked to its website and is not responsible for the contents of any such linked site. The inclusion of any link does not imply endorsement. Use of any such linked website is at the user's own risk.
+        OSS Security Hub has not reviewed all of the sites linked to its website and is not responsible for the contents of any such linked site. The inclusion of any link does not imply endorsement. Use of any such linked website is at the user's own risk.
       </p>
     </section>
 
     <section>
       <h2 class="text-2xl font-bold mb-3">7. Modifications</h2>
       <p class="text-slate-300 leading-relaxed">
-        Library Safety Checker may revise these terms of service at any time without notice. By using this website, you are agreeing to be bound by the then-current version of these terms.
+        OSS Security Hub may revise these terms of service at any time without notice. By using this website, you are agreeing to be bound by the then-current version of these terms.
       </p>
     </section>
 
@@ -111,7 +111,7 @@
     <section>
       <h2 class="text-2xl font-bold mb-3">11. Limitation of Liability</h2>
       <p class="text-slate-300 leading-relaxed">
-        In no case shall Library Safety Checker, its suppliers, or other related parties be liable for any damages, including lost profits, lost revenues, lost savings, or other special, consequential, indirect, or punitive damages, even if Library Safety Checker has been advised of the possibility of such damages.
+        In no case shall OSS Security Hub, its suppliers, or other related parties be liable for any damages, including lost profits, lost revenues, lost savings, or other special, consequential, indirect, or punitive damages, even if OSS Security Hub has been advised of the possibility of such damages.
       </p>
     </section>
 


### PR DESCRIPTION
## Summary

Renames the service from "Library Safety Checker" to "OSS Security Hub" across the entire codebase. Every user-facing reference has been updated: page titles, meta descriptions, og:title and og:description tags, Twitter card metadata, JSON-LD structured data (Organization, WebApplication, WebSite names), the navigation brand and mobile abbreviation (LSC → OSH), the footer copyright line, the FAQ schema on the homepage, all body copy in the Terms & Conditions page, and the User-Agent header sent to the crates.io API. The new name better reflects the multi-ecosystem, security-focused nature of the service.

### Changes
- **Modified** `app.py`
- **Modified** `templates/base.html`
- **Modified** `templates/index.html`
- **Modified** `templates/dashboard.html`
- **Modified** `templates/results.html`
- **Modified** `templates/comparison.html`
- **Modified** `templates/terms.html`

---
*Generated by [Railway](https://railway.com)*